### PR TITLE
Declare the explicit requirement for (fake)root

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-depends: debhelper (>= 9), libx11-dev, libxt-dev, x11proto-core-dev,
 Homepage: http://www.gedanken.org.uk/software/xbomb/
 Vcs-Git: git://github.com/alexdantas/xbomb.debian.git -b master
 Vcs-Browser: https://github.com/alexdantas/xbomb.debian
+Rules-Requires-Root: binary-targets
 
 Package: xbomb
 Architecture: any


### PR DESCRIPTION
The xbomb package currently requires (fake)root to produce the debs due to static non-root:root ownerships in the debs.