### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xbomb (2.2b-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 18:12:42 +0100
+
 xbomb (2.2b-1) unstable; urgency=medium
 
   * New upstream version (Closes: #757902)

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.5
 Build-depends: debhelper (>= 9), libx11-dev, libxt-dev, x11proto-core-dev,
                libxaw7-dev
 Homepage: http://www.gedanken.org.uk/software/xbomb/
-Vcs-Git: git://github.com/alexdantas/xbomb.debian.git -b master
+Vcs-Git: https://github.com/alexdantas/xbomb.debian.git -b master
 Vcs-Browser: https://github.com/alexdantas/xbomb.debian
 
 Package: xbomb


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
